### PR TITLE
auth:login command improvements: API base URL config & interactive prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,7 @@ Configure your API key with the GrowthBook SDK with your project
 
 ```
 USAGE
-  $ growthbook auth login -k <value> [-p <value>]
-
-FLAGS
-  -k, --apiKey=<value>   (required) Your GrowthBook secret API Key
-  -p, --profile=<value>  Optional profile (for projects that use multiple GrowthBook instances or organizations)
-                         (default: default)
+  $ growthbook auth login
 
 DESCRIPTION
   Configure your API key with the GrowthBook SDK with your project
@@ -77,10 +72,9 @@ USAGE
 FLAGS
   -o, --output=<value>      Output path for the app-features.ts file. All directories in this path should exist. If not
                             provided, the directory ./growthbook-types will be created in the current working directory.
-  -p, --profile=<value>     [default: default] Optional profile (for projects that use multiple GrowthBook instances)
-                            default: default)
-  -u, --apiBaseUrl=<value>  [default: https://api.growthbook.io] Your GrowthBook instance base URL (e.g.
-                            http://localhost:3100, default: https://api.growthbook.io)
+  -p, --profile=<value>     Optional profile (for projects that use multiple GrowthBook instances) default: default)
+  -u, --apiBaseUrl=<value>  Your GrowthBook instance base URL (e.g. http://localhost:3100, default:
+                            https://api.growthbook.io)
 
 DESCRIPTION
   Generate TypeScript types for all your features
@@ -101,11 +95,10 @@ FLAGS
   -e, --environment=<value>  (required) Environment that you would like to toggle
   -n, --enabled=<option>     (required) Enabled state of the feature
                              <options: true|false|on|off|1|0>
-  -p, --profile=<value>      [default: default] Optional profile (for projects that use multiple GrowthBook instances)
-                             default: default)
+  -p, --profile=<value>      Optional profile (for projects that use multiple GrowthBook instances) default: default)
   -r, --reason=<value>       The reason for toggling it on
-  -u, --apiBaseUrl=<value>   [default: https://api.growthbook.io] Your GrowthBook instance base URL (e.g.
-                             http://localhost:3100, default: https://api.growthbook.io)
+  -u, --apiBaseUrl=<value>   Your GrowthBook instance base URL (e.g. http://localhost:3100, default:
+                             https://api.growthbook.io)
 
 DESCRIPTION
   Toggle a feature on or off for a specific environment

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -1,46 +1,53 @@
-import {Command, Flags} from '@oclif/core'
+import {Command, ux} from '@oclif/core'
 import * as Fs from 'node:fs'
 import * as toml from '@iarna/toml'
 import {getGrowthBookConfigDirectory, getGrowthBookConfigFilePath} from '../../utils/file'
-import {DEFAULT_GROWTHBOOK_PROFILE} from '../../utils/constants'
-import {checkmark} from '../../utils/cli'
+import {DEFAULT_GROWTHBOOK_BASE_URL, DEFAULT_GROWTHBOOK_PROFILE} from '../../utils/constants'
+import {checkmark, xSymbol} from '../../utils/cli'
 
 export default class Login extends Command {
   static description = 'Configure your API key with the GrowthBook SDK with your project'
 
   static examples = []
 
-  static flags = {
-    apiKey: Flags.string({
-      char: 'k',
-      description: 'Your GrowthBook secret API Key',
-      required: true,
-    }),
-    profile: Flags.string({
-      char: 'p',
-      description: `Optional profile (for projects that use multiple GrowthBook instances or organizations) (default: ${DEFAULT_GROWTHBOOK_PROFILE})`,
-      required: false,
-    }),
-  }
+  static flags = {}
 
   static args = {}
 
   async run(): Promise<void> {
-    const {flags: {
-      apiKey,
-      profile = DEFAULT_GROWTHBOOK_PROFILE,
-    }} = await this.parse(Login)
+    const apiKey = await ux.prompt('What is your GrowthBook secret API Key?', {
+      type: 'hide',
+      required: true,
+    })
+    if (!apiKey) {
+      this.error(`${xSymbol} You must provide a GrowthBook secret API key to continue`)
+    }
 
-    this.writeApiKeyToGrowthBookConfig(apiKey, profile)
+    let profile = await ux.prompt(`What is the name of this profile? You can leave this blank (default: ${DEFAULT_GROWTHBOOK_PROFILE})`, {
+      required: false,
+    })
+    if (!profile) {
+      profile = DEFAULT_GROWTHBOOK_PROFILE
+    }
+
+    let apiBaseUrl = await ux.prompt(`What is the API base URL of the GrowthBook instance? If using GrowthBook cloud, you can leave this blank (e.g. http://localhost:3100, default: ${DEFAULT_GROWTHBOOK_BASE_URL})`, {
+      required: false,
+    })
+    if (!apiBaseUrl) {
+      apiBaseUrl = DEFAULT_GROWTHBOOK_BASE_URL
+    }
+
+    this.writeApiKeyToGrowthBookConfig(apiKey, profile, apiBaseUrl)
   }
 
   /**
    * Writes the API key to the config file. Will throw errors if it cannot read or write to the file
    * @param {string} apiKey The GrowthBook secret
    * @param {string} profile The profile to write in the config
+   * @param {string} apiBaseUrl The base URL of the GrowthBook API
    * @return void
    */
-  private writeApiKeyToGrowthBookConfig(apiKey: string, profile: string): void {
+  private writeApiKeyToGrowthBookConfig(apiKey: string, profile: string, apiBaseUrl: string): void {
     const configText = this.getGrowthBookConfigFileContents()
     const config = toml.parse(configText)
 
@@ -50,6 +57,7 @@ export default class Login extends Command {
 
     config[profile] = {
       growthbook_secret: apiKey,
+      api_base_url: apiBaseUrl,
     }
 
     const stringified = toml.stringify(config)

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -3,7 +3,7 @@ import * as Fs from 'node:fs'
 import * as toml from '@iarna/toml'
 import {getGrowthBookConfigDirectory, getGrowthBookConfigFilePath} from '../../utils/file'
 import {DEFAULT_GROWTHBOOK_BASE_URL, DEFAULT_GROWTHBOOK_PROFILE} from '../../utils/constants'
-import {checkmark, xSymbol} from '../../utils/cli'
+import {Icons} from '../../utils/cli'
 
 export default class Login extends Command {
   static description = 'Configure your API key with the GrowthBook SDK with your project'
@@ -20,7 +20,7 @@ export default class Login extends Command {
       required: true,
     })
     if (!apiKey) {
-      this.error(`${xSymbol} You must provide a GrowthBook secret API key to continue`)
+      this.error(`${Icons.xSymbol} You must provide a GrowthBook secret API key to continue`)
     }
 
     let profile = await ux.prompt(`What is the name of this profile? You can leave this blank (default: ${DEFAULT_GROWTHBOOK_PROFILE})`, {
@@ -110,7 +110,7 @@ export default class Login extends Command {
     try {
       Fs.writeFileSync(configFilePath, fileContents)
 
-      this.log(`The GrowthBook config has been written at ~/.growthbook/config.toml ${checkmark}`)
+      this.log(`The GrowthBook config has been written at ~/.growthbook/config.toml ${Icons.checkmark}`)
     } catch (error) {
       this.error(`💥 Cannot write to file at ${configFilePath} \n` + error)
     }

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -3,7 +3,7 @@ import * as Fs from 'node:fs'
 import * as toml from '@iarna/toml'
 import {getGrowthBookConfigFilePath} from '../../utils/file'
 import {getGrowthBookConfigToml} from '../../utils/config'
-import {checkmark} from '../../utils/cli'
+import {Icons} from '../../utils/cli'
 
 export default class Logout extends Command {
   static description = 'Removes GrowthBook API key configurations'
@@ -46,7 +46,7 @@ export default class Logout extends Command {
     try {
       Fs.writeFileSync(configFilePath, '')
 
-      ux.action.stop(checkmark)
+      ux.action.stop(Icons.checkmark)
     } catch (error) {
       this.error(`💥 Cannot write to file at ${configFilePath}. It may not exist or there may be insufficient permissions. \n` + error)
     }
@@ -71,7 +71,7 @@ export default class Logout extends Command {
     try {
       Fs.writeFileSync(configFilePath, stringified)
 
-      ux.action.stop(checkmark)
+      ux.action.stop(Icons.checkmark)
     } catch (error) {
       this.error(`💥 Cannot write to file at ${configFilePath}. It may not exist or there may be insufficient permissions. \n` + error)
     }

--- a/src/commands/features/generate-types.ts
+++ b/src/commands/features/generate-types.ts
@@ -10,7 +10,7 @@ import {
   DEFAULT_GROWTHBOOK_TYPES_DESTINATION,
   GROWTHBOOK_APP_FEATURES_FILENAME,
 } from '../../utils/constants'
-import {baseGrowthBookCliFlags, checkmark} from '../../utils/cli'
+import {baseGrowthBookCliFlags, Icons} from '../../utils/cli'
 
 export default class GenerateTypes extends Command {
   static description = 'Generate TypeScript types for all your features'
@@ -41,7 +41,7 @@ export default class GenerateTypes extends Command {
     const config = getGrowthBookProfileConfigAndThrowForCommand(profileUsed, this)
     const baseUrlUsed = apiBaseUrl || config.apiBaseUrl || DEFAULT_GROWTHBOOK_BASE_URL
 
-    ux.action.stop(checkmark)
+    ux.action.stop(Icons.checkmark)
 
     const {apiKey} = config
 
@@ -51,7 +51,7 @@ export default class GenerateTypes extends Command {
       const features: SimpleFeatureResponse = await fetchAllPaginatedFeatures(baseUrlUsed, apiKey)
       const typeScriptOutput = getCompiledTypeScriptTemplateForFeatures(features)
 
-      ux.action.stop(checkmark)
+      ux.action.stop(Icons.checkmark)
 
       let outputPath = output
       if (!outputPath) {
@@ -81,8 +81,8 @@ export default class GenerateTypes extends Command {
 
       Fs.writeFileSync(fullyQualifiedPath + '/' + GROWTHBOOK_APP_FEATURES_FILENAME, typeScriptContents)
 
-      ux.action.stop(checkmark)
-      this.log(`${checkmark} Successfully wrote TypeScript definitions to ${fullyQualifiedPath}`)
+      ux.action.stop(Icons.checkmark)
+      this.log(`${Icons.checkmark} Successfully wrote TypeScript definitions to ${fullyQualifiedPath}`)
     } catch (error) {
       this.error('💥 Could not write TypeScript definition file to disk' + error)
     }

--- a/src/commands/features/generate-types.ts
+++ b/src/commands/features/generate-types.ts
@@ -1,10 +1,11 @@
 import * as Fs from 'node:fs'
 import * as Path from 'node:path'
 import {Command, Flags, ux} from '@oclif/core'
-import {getGrowthBookProfileConfig} from '../../utils/config'
+import {getGrowthBookProfileConfigAndThrowForCommand} from '../../utils/config'
 import {fetchAllPaginatedFeatures, SimpleFeatureResponse} from '../../utils/http'
 import {getCompiledTypeScriptTemplateForFeatures} from '../../utils/templating'
 import {
+  DEFAULT_GROWTHBOOK_BASE_URL,
   DEFAULT_GROWTHBOOK_PROFILE,
   DEFAULT_GROWTHBOOK_TYPES_DESTINATION,
   GROWTHBOOK_APP_FEATURES_FILENAME,
@@ -36,16 +37,9 @@ export default class GenerateTypes extends Command {
 
     ux.action.start('Getting GrowthBook config')
 
-    const config = getGrowthBookProfileConfig(profile)
-    if (!config) {
-      if (profile === DEFAULT_GROWTHBOOK_PROFILE) {
-        // Default profile
-        this.error('💥 Invalid GrowthBook config. Configure the CLI with the following command:\n\n $ growthbook auth login')
-      } else {
-        // User is trying to use a custom profile
-        this.error(`💥 Cannot find config for profile '${DEFAULT_GROWTHBOOK_PROFILE}'. Configure the CLI with the following command:\n\n $ growthbook auth login`)
-      }
-    }
+    const profileUsed = profile || DEFAULT_GROWTHBOOK_PROFILE
+    const config = getGrowthBookProfileConfigAndThrowForCommand(profileUsed, this)
+    const baseUrlUsed = apiBaseUrl || config.apiBaseUrl || DEFAULT_GROWTHBOOK_BASE_URL
 
     ux.action.stop(checkmark)
 
@@ -54,7 +48,7 @@ export default class GenerateTypes extends Command {
     try {
       ux.action.start('Fetching features')
 
-      const features: SimpleFeatureResponse = await fetchAllPaginatedFeatures(apiBaseUrl, apiKey)
+      const features: SimpleFeatureResponse = await fetchAllPaginatedFeatures(baseUrlUsed, apiKey)
       const typeScriptOutput = getCompiledTypeScriptTemplateForFeatures(features)
 
       ux.action.stop(checkmark)

--- a/src/commands/features/toggle.ts
+++ b/src/commands/features/toggle.ts
@@ -1,5 +1,5 @@
 import {Args, Command, Flags} from '@oclif/core'
-import {baseGrowthBookCliFlags, checkmark, parseBooleanFromString} from '../../utils/cli'
+import {baseGrowthBookCliFlags, Icons, parseBooleanFromString} from '../../utils/cli'
 import {toggleFeature} from '../../utils/http'
 import {getGrowthBookProfileConfigAndThrowForCommand} from '../../utils/config'
 import {DEFAULT_GROWTHBOOK_BASE_URL, DEFAULT_GROWTHBOOK_PROFILE} from '../../utils/constants'
@@ -63,6 +63,6 @@ export default class FeaturesToggle extends Command {
     })
 
     this.logJson(updatedFeature)
-    this.log(`\n${checkmark} The feature was updated!`)
+    this.log(`\n${Icons.checkmark} The feature was updated!`)
   }
 }

--- a/src/commands/features/toggle.ts
+++ b/src/commands/features/toggle.ts
@@ -2,6 +2,7 @@ import {Args, Command, Flags} from '@oclif/core'
 import {baseGrowthBookCliFlags, checkmark, parseBooleanFromString} from '../../utils/cli'
 import {toggleFeature} from '../../utils/http'
 import {getGrowthBookProfileConfigAndThrowForCommand} from '../../utils/config'
+import {DEFAULT_GROWTHBOOK_BASE_URL, DEFAULT_GROWTHBOOK_PROFILE} from '../../utils/constants'
 
 export default class FeaturesToggle extends Command {
   static description = 'Toggle a feature on or off for a specific environment'
@@ -48,12 +49,13 @@ export default class FeaturesToggle extends Command {
       profile,
       apiBaseUrl,
     }} = await this.parse(FeaturesToggle)
-
-    const config = getGrowthBookProfileConfigAndThrowForCommand(profile, this)
+    const profileUsed = profile || DEFAULT_GROWTHBOOK_PROFILE
+    const config = getGrowthBookProfileConfigAndThrowForCommand(profileUsed, this)
+    const baseUrlUsed = apiBaseUrl || config.apiBaseUrl || DEFAULT_GROWTHBOOK_BASE_URL
 
     const parsedEnabled = parseBooleanFromString(enabled) || false
 
-    const updatedFeature = await toggleFeature(apiBaseUrl, config.apiKey, {
+    const updatedFeature = await toggleFeature(baseUrlUsed, config.apiKey, {
       id: featureKey,
       reason,
       enabled: parsedEnabled,

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -6,6 +6,7 @@ import {DEFAULT_GROWTHBOOK_BASE_URL, DEFAULT_GROWTHBOOK_PROFILE} from './constan
  * Green checkmark to be used with ux.action.stop(checkmark) for nicer feedback UI
  */
 export const checkmark = chalk.green('✔')
+export const xSymbol = chalk.red('𝒙')
 
 export const TRUTHY_VALUES = [1, '1', 'true', 'on']
 export const FALSY_VALUES = [0, '0', 'false', 'off']
@@ -30,12 +31,10 @@ export const baseGrowthBookCliFlags = {
     char: 'u',
     description: `Your GrowthBook instance base URL (e.g. http://localhost:3100, default: ${DEFAULT_GROWTHBOOK_BASE_URL})`,
     required: false,
-    default: DEFAULT_GROWTHBOOK_BASE_URL,
   }),
   profile: Flags.string({
     char: 'p',
     description: `Optional profile (for projects that use multiple GrowthBook instances) default: ${DEFAULT_GROWTHBOOK_PROFILE})`,
-    default: DEFAULT_GROWTHBOOK_PROFILE,
     required: false,
   }),
 }

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -2,11 +2,13 @@ import * as chalk from 'chalk'
 import {Flags} from '@oclif/core'
 import {DEFAULT_GROWTHBOOK_BASE_URL, DEFAULT_GROWTHBOOK_PROFILE} from './constants'
 
-/**
- * Green checkmark to be used with ux.action.stop(checkmark) for nicer feedback UI
- */
-export const checkmark = chalk.green('✔')
-export const xSymbol = chalk.red('𝒙')
+export const Icons = {
+  // Green checkmark to be used with ux.action.stop(checkmark) for nicer feedback UI
+  checkmark: chalk.green('✔'),
+
+  // Red X symbol for sad path feedback
+  xSymbol: chalk.red('𝒙'),
+}
 
 export const TRUTHY_VALUES = [1, '1', 'true', 'on']
 export const FALSY_VALUES = [0, '0', 'false', 'off']

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,15 +1,17 @@
 import * as Fs from 'node:fs'
 import * as toml from '@iarna/toml'
-import {getGrowthBookConfigFilePath} from './file'
-import {DEFAULT_GROWTHBOOK_PROFILE} from './constants'
 import {Command} from '@oclif/core'
+import {getGrowthBookConfigFilePath} from './file'
+import {DEFAULT_GROWTHBOOK_BASE_URL, DEFAULT_GROWTHBOOK_PROFILE} from './constants'
 
 export type GrowthBookCLIConfig = {
   apiKey: string
+  apiBaseUrl: string
 }
 
 export type GrowthBookTomlProfile = {
   growthbook_secret: string
+  api_base_url: string
 }
 
 /**
@@ -48,8 +50,14 @@ export function getGrowthBookProfileConfig(profileKey: string): GrowthBookCLICon
       return null
     }
 
+    let apiBaseUrl = profile.api_base_url
+    if (!apiBaseUrl) {
+      apiBaseUrl = DEFAULT_GROWTHBOOK_BASE_URL
+    }
+
     return {
       apiKey,
+      apiBaseUrl,
     }
   } catch {
     return null
@@ -70,7 +78,7 @@ export function getGrowthBookProfileConfigAndThrowForCommand(profileKey: string,
       command.error('💥 Invalid GrowthBook config. Configure the CLI with the following command:\n\n $ growthbook auth login')
     } else {
       // User is trying to use a custom profile
-      command.error(`💥 Cannot find config for profile '${DEFAULT_GROWTHBOOK_PROFILE}'. Configure the CLI with the following command:`)
+      command.error(`💥 Cannot find config for profile '${DEFAULT_GROWTHBOOK_PROFILE}'. Configure the CLI with the following command:\n\n $ growthbook auth login`)
     }
   }
 

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,5 +1,5 @@
 import fetch, {RequestInit} from 'node-fetch'
-import {checkmark} from './cli'
+import {Icons} from './cli'
 import {SimplifiedFeature} from './feature'
 import {Configuration, Feature, FeaturesApi} from '../generated/api'
 
@@ -65,7 +65,7 @@ export const fetchAllPaginatedFeatures = async (apiBaseUrl: string, token: strin
     offset = nextOffset
     shouldFetch = hasMore
 
-    console.log('Fetched features at URL:', fullUrl, checkmark)
+    console.log('Fetched features at URL:', fullUrl, Icons.checkmark)
   }
 
   return allFeatures


### PR DESCRIPTION
Improvements to the configuration/login command:

- adds API base URL to the config
- uses interactive prompts to collect inputs
- existing commands `features:generate-types` and `features:toggle` use these values

Closes:

- closes https://github.com/growthbook/growthbook-cli/issues/25
- closes https://github.com/growthbook/growthbook-cli/issues/26
- closes https://linear.app/growthbook/issue/GB-231


https://github.com/growthbook/growthbook-cli/assets/113377031/53793f97-dc42-4669-81e0-d4697af68705

