### PR TITLE
Allow `growthbook auth login`  to accept its arguments as flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,13 @@ Configure your API key with the GrowthBook SDK with your project
 
 ```
 USAGE
-  $ growthbook auth login
+  $ growthbook auth login [-u <value>] [-p <value>] [--apiKey <value>]
+
+FLAGS
+  -p, --profile=<value>     Optional profile (for projects that use multiple GrowthBook instances) default: default)
+  -u, --apiBaseUrl=<value>  Your GrowthBook instance base URL (e.g. http://localhost:3100, default:
+                            https://api.growthbook.io)
+  --apiKey=<value>          Your GrowthBook secret API key
 
 DESCRIPTION
   Configure your API key with the GrowthBook SDK with your project

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "growthbook",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "The GrowthBook command-line interface (CLI) for working with the GrowthBook A/B testing, feature flagging, and experimentation platform",
   "bin": {
     "growthbook": "./bin/run"

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -31,7 +31,17 @@ export default class Login extends Command {
         apiBaseUrl,
       },
     } = await this.parse(Login)
-    let profileUsed = profile || DEFAULT_GROWTHBOOK_PROFILE
+    let profileUsed = profile
+
+    if (!profileUsed) {
+      profileUsed = await ux.prompt(`What is the name of this profile? You can leave this blank (default: ${DEFAULT_GROWTHBOOK_PROFILE})`, {
+        required: false,
+      })
+      if (!profileUsed) {
+        profileUsed = DEFAULT_GROWTHBOOK_PROFILE
+      }
+    }
+
     const {apiKey: configApiKey, apiBaseUrl: configApiBaseUrl} = getGrowthBookProfileConfigAndThrowForCommand(profileUsed, this)
     let baseUrlUsed = apiBaseUrl || configApiBaseUrl || DEFAULT_GROWTHBOOK_BASE_URL
 
@@ -44,15 +54,6 @@ export default class Login extends Command {
       })
       if (!apiKeyUsed) {
         this.error(`${Icons.xSymbol} You must provide a GrowthBook secret API key to continue`)
-      }
-    }
-
-    if (!profileUsed) {
-      profileUsed = await ux.prompt(`What is the name of this profile? You can leave this blank (default: ${DEFAULT_GROWTHBOOK_PROFILE})`, {
-        required: false,
-      })
-      if (!profileUsed) {
-        profileUsed = DEFAULT_GROWTHBOOK_PROFILE
       }
     }
 

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -1,43 +1,71 @@
-import {Command, ux} from '@oclif/core'
+import {Command, Flags, ux} from '@oclif/core'
 import * as Fs from 'node:fs'
 import * as toml from '@iarna/toml'
 import {getGrowthBookConfigDirectory, getGrowthBookConfigFilePath} from '../../utils/file'
 import {DEFAULT_GROWTHBOOK_BASE_URL, DEFAULT_GROWTHBOOK_PROFILE} from '../../utils/constants'
-import {Icons} from '../../utils/cli'
+import {Icons, baseGrowthBookCliFlags} from '../../utils/cli'
+import {getGrowthBookProfileConfigAndThrowForCommand} from '../../utils/config'
 
 export default class Login extends Command {
   static description = 'Configure your API key with the GrowthBook SDK with your project'
 
   static examples = []
 
-  static flags = {}
+  static flags = {
+    ...baseGrowthBookCliFlags,
+    apiKey: Flags.string({
+      description: 'Your GrowthBook secret API key',
+      required: false,
+    }),
+  }
 
   static args = {}
 
   async run(): Promise<void> {
-    const apiKey = await ux.prompt('What is your GrowthBook secret API Key?', {
-      type: 'hide',
-      required: true,
-    })
-    if (!apiKey) {
-      this.error(`${Icons.xSymbol} You must provide a GrowthBook secret API key to continue`)
+    const {
+      args: {
+        apiKey,
+      },
+      flags: {
+        profile,
+        apiBaseUrl,
+      },
+    } = await this.parse(Login)
+    let profileUsed = profile || DEFAULT_GROWTHBOOK_PROFILE
+    const {apiKey: configApiKey, apiBaseUrl: configApiBaseUrl} = getGrowthBookProfileConfigAndThrowForCommand(profileUsed, this)
+    let baseUrlUsed = apiBaseUrl || configApiBaseUrl || DEFAULT_GROWTHBOOK_BASE_URL
+
+    let apiKeyUsed = apiKey || configApiKey
+
+    if (!apiKeyUsed) {
+      apiKeyUsed = await ux.prompt('What is your GrowthBook secret API Key?', {
+        type: 'hide',
+        required: true,
+      })
+      if (!apiKeyUsed) {
+        this.error(`${Icons.xSymbol} You must provide a GrowthBook secret API key to continue`)
+      }
     }
 
-    let profile = await ux.prompt(`What is the name of this profile? You can leave this blank (default: ${DEFAULT_GROWTHBOOK_PROFILE})`, {
-      required: false,
-    })
-    if (!profile) {
-      profile = DEFAULT_GROWTHBOOK_PROFILE
+    if (!profileUsed) {
+      profileUsed = await ux.prompt(`What is the name of this profile? You can leave this blank (default: ${DEFAULT_GROWTHBOOK_PROFILE})`, {
+        required: false,
+      })
+      if (!profileUsed) {
+        profileUsed = DEFAULT_GROWTHBOOK_PROFILE
+      }
     }
 
-    let apiBaseUrl = await ux.prompt(`What is the API base URL of the GrowthBook instance? If using GrowthBook cloud, you can leave this blank (e.g. http://localhost:3100, default: ${DEFAULT_GROWTHBOOK_BASE_URL})`, {
-      required: false,
-    })
-    if (!apiBaseUrl) {
-      apiBaseUrl = DEFAULT_GROWTHBOOK_BASE_URL
+    if (!baseUrlUsed) {
+      baseUrlUsed = await ux.prompt(`What is the API base URL of the GrowthBook instance? If using GrowthBook cloud, you can leave this blank (e.g. http://localhost:3100, default: ${DEFAULT_GROWTHBOOK_BASE_URL})`, {
+        required: false,
+      })
+      if (!baseUrlUsed) {
+        baseUrlUsed = DEFAULT_GROWTHBOOK_BASE_URL
+      }
     }
 
-    this.writeApiKeyToGrowthBookConfig(apiKey, profile, apiBaseUrl)
+    this.writeApiKeyToGrowthBookConfig(apiKeyUsed, profileUsed, baseUrlUsed)
   }
 
   /**


### PR DESCRIPTION
The primary motivation behind this change is to allow running commands in a CI/automated environment. This also lets you do things like generate types for features with an npm command.

Fixes https://github.com/growthbook/growthbook-cli/issues/36