### PR TITLE
Revert "Allow `growthbook auth login`  to accept its arguments as flags"

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,7 @@ Configure your API key with the GrowthBook SDK with your project
 
 ```
 USAGE
-  $ growthbook auth login [-u <value>] [-p <value>] [--apiKey <value>]
-
-FLAGS
-  -p, --profile=<value>     Optional profile (for projects that use multiple GrowthBook instances) default: default)
-  -u, --apiBaseUrl=<value>  Your GrowthBook instance base URL (e.g. http://localhost:3100, default:
-                            https://api.growthbook.io)
-  --apiKey=<value>          Your GrowthBook secret API key
+  $ growthbook auth login
 
 DESCRIPTION
   Configure your API key with the GrowthBook SDK with your project

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -1,72 +1,43 @@
-import {Command, Flags, ux} from '@oclif/core'
+import {Command, ux} from '@oclif/core'
 import * as Fs from 'node:fs'
 import * as toml from '@iarna/toml'
 import {getGrowthBookConfigDirectory, getGrowthBookConfigFilePath} from '../../utils/file'
 import {DEFAULT_GROWTHBOOK_BASE_URL, DEFAULT_GROWTHBOOK_PROFILE} from '../../utils/constants'
-import {Icons, baseGrowthBookCliFlags} from '../../utils/cli'
-import {getGrowthBookProfileConfigAndThrowForCommand} from '../../utils/config'
+import {Icons} from '../../utils/cli'
 
 export default class Login extends Command {
   static description = 'Configure your API key with the GrowthBook SDK with your project'
 
   static examples = []
 
-  static flags = {
-    ...baseGrowthBookCliFlags,
-    apiKey: Flags.string({
-      description: 'Your GrowthBook secret API key',
-      required: false,
-    }),
-  }
+  static flags = {}
 
   static args = {}
 
   async run(): Promise<void> {
-    const {
-      args: {
-        apiKey,
-      },
-      flags: {
-        profile,
-        apiBaseUrl,
-      },
-    } = await this.parse(Login)
-    let profileUsed = profile
-
-    if (!profileUsed) {
-      profileUsed = await ux.prompt(`What is the name of this profile? You can leave this blank (default: ${DEFAULT_GROWTHBOOK_PROFILE})`, {
-        required: false,
-      })
-      if (!profileUsed) {
-        profileUsed = DEFAULT_GROWTHBOOK_PROFILE
-      }
+    const apiKey = await ux.prompt('What is your GrowthBook secret API Key?', {
+      type: 'hide',
+      required: true,
+    })
+    if (!apiKey) {
+      this.error(`${Icons.xSymbol} You must provide a GrowthBook secret API key to continue`)
     }
 
-    const {apiKey: configApiKey, apiBaseUrl: configApiBaseUrl} = getGrowthBookProfileConfigAndThrowForCommand(profileUsed, this)
-    let baseUrlUsed = apiBaseUrl || configApiBaseUrl || DEFAULT_GROWTHBOOK_BASE_URL
-
-    let apiKeyUsed = apiKey || configApiKey
-
-    if (!apiKeyUsed) {
-      apiKeyUsed = await ux.prompt('What is your GrowthBook secret API Key?', {
-        type: 'hide',
-        required: true,
-      })
-      if (!apiKeyUsed) {
-        this.error(`${Icons.xSymbol} You must provide a GrowthBook secret API key to continue`)
-      }
+    let profile = await ux.prompt(`What is the name of this profile? You can leave this blank (default: ${DEFAULT_GROWTHBOOK_PROFILE})`, {
+      required: false,
+    })
+    if (!profile) {
+      profile = DEFAULT_GROWTHBOOK_PROFILE
     }
 
-    if (!baseUrlUsed) {
-      baseUrlUsed = await ux.prompt(`What is the API base URL of the GrowthBook instance? If using GrowthBook cloud, you can leave this blank (e.g. http://localhost:3100, default: ${DEFAULT_GROWTHBOOK_BASE_URL})`, {
-        required: false,
-      })
-      if (!baseUrlUsed) {
-        baseUrlUsed = DEFAULT_GROWTHBOOK_BASE_URL
-      }
+    let apiBaseUrl = await ux.prompt(`What is the API base URL of the GrowthBook instance? If using GrowthBook cloud, you can leave this blank (e.g. http://localhost:3100, default: ${DEFAULT_GROWTHBOOK_BASE_URL})`, {
+      required: false,
+    })
+    if (!apiBaseUrl) {
+      apiBaseUrl = DEFAULT_GROWTHBOOK_BASE_URL
     }
 
-    this.writeApiKeyToGrowthBookConfig(apiKeyUsed, profileUsed, baseUrlUsed)
+    this.writeApiKeyToGrowthBookConfig(apiKey, profile, apiBaseUrl)
   }
 
   /**


### PR DESCRIPTION
Reverts growthbook/growthbook-cli#37

It causes the following issue and users are unable to configure the CLI:

```
What is the name of this profile? You can leave this blank (default: default): default
 ›   Error: 💥 Invalid GrowthBook config. Configure the CLI with the following command:
 ›
 ›    $ growthbook auth login
```