### PR TITLE
Fix error for a non-existent custom profile

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,18 +1,21 @@
-import * as Fs from 'node:fs'
-import * as toml from '@iarna/toml'
-import {Command} from '@oclif/core'
-import {getGrowthBookConfigFilePath} from './file'
-import {DEFAULT_GROWTHBOOK_BASE_URL, DEFAULT_GROWTHBOOK_PROFILE} from './constants'
+import * as Fs from "node:fs";
+import * as toml from "@iarna/toml";
+import { Command } from "@oclif/core";
+import { getGrowthBookConfigFilePath } from "./file";
+import {
+  DEFAULT_GROWTHBOOK_BASE_URL,
+  DEFAULT_GROWTHBOOK_PROFILE,
+} from "./constants";
 
 export type GrowthBookCLIConfig = {
-  apiKey: string
-  apiBaseUrl: string
-}
+  apiKey: string;
+  apiBaseUrl: string;
+};
 
 export type GrowthBookTomlProfile = {
-  growthbook_secret: string
-  api_base_url: string
-}
+  growthbook_secret: string;
+  api_base_url: string;
+};
 
 /**
  * Get the text content of the config file.
@@ -20,11 +23,11 @@ export type GrowthBookTomlProfile = {
  */
 export function getGrowthBookConfigToml(): string {
   try {
-    const filePath = getGrowthBookConfigFilePath()
+    const filePath = getGrowthBookConfigFilePath();
 
-    return Fs.readFileSync(filePath, 'utf-8')
+    return Fs.readFileSync(filePath, "utf-8");
   } catch {
-    return ''
+    return "";
   }
 }
 
@@ -33,34 +36,36 @@ export function getGrowthBookConfigToml(): string {
  * @param {string} profileKey The desired profile in the GrowthBook config
  * @return {GrowthBookCLIConfig | null} Valid GrowthBook config. If no valid config found, this will be null.
  */
-export function getGrowthBookProfileConfig(profileKey: string): GrowthBookCLIConfig | null {
+export function getGrowthBookProfileConfig(
+  profileKey: string
+): GrowthBookCLIConfig | null {
   try {
-    const filePath = getGrowthBookConfigFilePath()
+    const filePath = getGrowthBookConfigFilePath();
 
-    const configText = Fs.readFileSync(filePath, 'utf-8')
-    const config = toml.parse(configText)
+    const configText = Fs.readFileSync(filePath, "utf-8");
+    const config = toml.parse(configText);
 
-    const profile = config[profileKey] as GrowthBookTomlProfile | undefined
+    const profile = config[profileKey] as GrowthBookTomlProfile | undefined;
     if (!profile) {
-      return null
+      return null;
     }
 
-    const apiKey = profile.growthbook_secret
+    const apiKey = profile.growthbook_secret;
     if (!apiKey) {
-      return null
+      return null;
     }
 
-    let apiBaseUrl = profile.api_base_url
+    let apiBaseUrl = profile.api_base_url;
     if (!apiBaseUrl) {
-      apiBaseUrl = DEFAULT_GROWTHBOOK_BASE_URL
+      apiBaseUrl = DEFAULT_GROWTHBOOK_BASE_URL;
     }
 
     return {
       apiKey,
       apiBaseUrl,
-    }
+    };
   } catch {
-    return null
+    return null;
   }
 }
 
@@ -70,17 +75,24 @@ export function getGrowthBookProfileConfig(profileKey: string): GrowthBookCLICon
  * @param command {Command}
  * @return {GrowthBookCLIConfig | null} Valid GrowthBook config. If no valid config found, this will be null but the application would
  */
-export function getGrowthBookProfileConfigAndThrowForCommand(profileKey: string, command: Command): GrowthBookCLIConfig | never {
-  const config = getGrowthBookProfileConfig(profileKey)
+export function getGrowthBookProfileConfigAndThrowForCommand(
+  profileKey: string,
+  command: Command
+): GrowthBookCLIConfig | never {
+  const config = getGrowthBookProfileConfig(profileKey);
   if (!config) {
     if (profileKey === DEFAULT_GROWTHBOOK_PROFILE) {
       // Default profile
-      command.error('💥 Invalid GrowthBook config. Configure the CLI with the following command:\n\n $ growthbook auth login')
+      command.error(
+        "💥 Invalid GrowthBook config. Configure the CLI with the following command:\n\n $ growthbook auth login"
+      );
     } else {
       // User is trying to use a custom profile
-      command.error(`💥 Cannot find config for profile '${DEFAULT_GROWTHBOOK_PROFILE}'. Configure the CLI with the following command:\n\n $ growthbook auth login`)
+      command.error(
+        `💥 Cannot find config for profile '${profileKey}'. Configure the CLI with the following command:\n\n $ growthbook auth login`
+      );
     }
   }
 
-  return config
+  return config;
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -2,10 +2,7 @@ import * as Fs from 'node:fs'
 import * as toml from '@iarna/toml'
 import {Command} from '@oclif/core'
 import {getGrowthBookConfigFilePath} from './file'
-import {
-  DEFAULT_GROWTHBOOK_BASE_URL,
-  DEFAULT_GROWTHBOOK_PROFILE,
-} from './constants'
+import {DEFAULT_GROWTHBOOK_BASE_URL, DEFAULT_GROWTHBOOK_PROFILE} from './constants'
 
 export type GrowthBookCLIConfig = {
   apiKey: string

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -73,7 +73,7 @@ export function getGrowthBookProfileConfig(
  * Will return do standard configuration missing messaging if there's an error calling {@link getGrowthBookProfileConfig}
  * @param profileKey {string}
  * @param command {Command}
- * @return {GrowthBookCLIConfig | null} Valid GrowthBook config. If no valid config found, this will be null but the application would
+ * @return {GrowthBookCLIConfig | null} Valid GrowthBook config. If no valid config found, this will be null but the application would display an error and exit.
  */
 export function getGrowthBookProfileConfigAndThrowForCommand(
   profileKey: string,

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -8,14 +8,14 @@ import {
 } from './constants'
 
 export type GrowthBookCLIConfig = {
-  apiKey: string;
-  apiBaseUrl: string;
-};
+  apiKey: string
+  apiBaseUrl: string
+}
 
 export type GrowthBookTomlProfile = {
-  growthbook_secret: string;
-  api_base_url: string;
-};
+  growthbook_secret: string
+  api_base_url: string
+}
 
 /**
  * Get the text content of the config file.
@@ -36,9 +36,7 @@ export function getGrowthBookConfigToml(): string {
  * @param {string} profileKey The desired profile in the GrowthBook config
  * @return {GrowthBookCLIConfig | null} Valid GrowthBook config. If no valid config found, this will be null.
  */
-export function getGrowthBookProfileConfig(
-  profileKey: string,
-): GrowthBookCLIConfig | null {
+export function getGrowthBookProfileConfig(profileKey: string): GrowthBookCLIConfig | null {
   try {
     const filePath = getGrowthBookConfigFilePath()
 
@@ -75,22 +73,15 @@ export function getGrowthBookProfileConfig(
  * @param command {Command}
  * @return {GrowthBookCLIConfig | null} Valid GrowthBook config. If no valid config found, this will be null but the application would display an error and exit.
  */
-export function getGrowthBookProfileConfigAndThrowForCommand(
-  profileKey: string,
-  command: Command,
-): GrowthBookCLIConfig | never {
+export function getGrowthBookProfileConfigAndThrowForCommand(profileKey: string, command: Command): GrowthBookCLIConfig | never {
   const config = getGrowthBookProfileConfig(profileKey)
   if (!config) {
     if (profileKey === DEFAULT_GROWTHBOOK_PROFILE) {
       // Default profile
-      command.error(
-        '💥 Invalid GrowthBook config. Configure the CLI with the following command:\n\n $ growthbook auth login',
-      )
+      command.error('💥 Invalid GrowthBook config. Configure the CLI with the following command:\n\n $ growthbook auth login')
     } else {
       // User is trying to use a custom profile
-      command.error(
-        `💥 Cannot find config for profile '${profileKey}'. Configure the CLI with the following command:\n\n $ growthbook auth login`,
-      )
+      command.error(`💥 Cannot find config for profile '${profileKey}'. Configure the CLI with the following command:\n\n $ growthbook auth login`)
     }
   }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,11 +1,11 @@
-import * as Fs from "node:fs";
-import * as toml from "@iarna/toml";
-import { Command } from "@oclif/core";
-import { getGrowthBookConfigFilePath } from "./file";
+import * as Fs from 'node:fs'
+import * as toml from '@iarna/toml'
+import {Command} from '@oclif/core'
+import {getGrowthBookConfigFilePath} from './file'
 import {
   DEFAULT_GROWTHBOOK_BASE_URL,
   DEFAULT_GROWTHBOOK_PROFILE,
-} from "./constants";
+} from './constants'
 
 export type GrowthBookCLIConfig = {
   apiKey: string;
@@ -23,11 +23,11 @@ export type GrowthBookTomlProfile = {
  */
 export function getGrowthBookConfigToml(): string {
   try {
-    const filePath = getGrowthBookConfigFilePath();
+    const filePath = getGrowthBookConfigFilePath()
 
-    return Fs.readFileSync(filePath, "utf-8");
+    return Fs.readFileSync(filePath, 'utf-8')
   } catch {
-    return "";
+    return ''
   }
 }
 
@@ -37,35 +37,35 @@ export function getGrowthBookConfigToml(): string {
  * @return {GrowthBookCLIConfig | null} Valid GrowthBook config. If no valid config found, this will be null.
  */
 export function getGrowthBookProfileConfig(
-  profileKey: string
+  profileKey: string,
 ): GrowthBookCLIConfig | null {
   try {
-    const filePath = getGrowthBookConfigFilePath();
+    const filePath = getGrowthBookConfigFilePath()
 
-    const configText = Fs.readFileSync(filePath, "utf-8");
-    const config = toml.parse(configText);
+    const configText = Fs.readFileSync(filePath, 'utf-8')
+    const config = toml.parse(configText)
 
-    const profile = config[profileKey] as GrowthBookTomlProfile | undefined;
+    const profile = config[profileKey] as GrowthBookTomlProfile | undefined
     if (!profile) {
-      return null;
+      return null
     }
 
-    const apiKey = profile.growthbook_secret;
+    const apiKey = profile.growthbook_secret
     if (!apiKey) {
-      return null;
+      return null
     }
 
-    let apiBaseUrl = profile.api_base_url;
+    let apiBaseUrl = profile.api_base_url
     if (!apiBaseUrl) {
-      apiBaseUrl = DEFAULT_GROWTHBOOK_BASE_URL;
+      apiBaseUrl = DEFAULT_GROWTHBOOK_BASE_URL
     }
 
     return {
       apiKey,
       apiBaseUrl,
-    };
+    }
   } catch {
-    return null;
+    return null
   }
 }
 
@@ -77,22 +77,22 @@ export function getGrowthBookProfileConfig(
  */
 export function getGrowthBookProfileConfigAndThrowForCommand(
   profileKey: string,
-  command: Command
+  command: Command,
 ): GrowthBookCLIConfig | never {
-  const config = getGrowthBookProfileConfig(profileKey);
+  const config = getGrowthBookProfileConfig(profileKey)
   if (!config) {
     if (profileKey === DEFAULT_GROWTHBOOK_PROFILE) {
       // Default profile
       command.error(
-        "💥 Invalid GrowthBook config. Configure the CLI with the following command:\n\n $ growthbook auth login"
-      );
+        '💥 Invalid GrowthBook config. Configure the CLI with the following command:\n\n $ growthbook auth login',
+      )
     } else {
       // User is trying to use a custom profile
       command.error(
-        `💥 Cannot find config for profile '${profileKey}'. Configure the CLI with the following command:\n\n $ growthbook auth login`
-      );
+        `💥 Cannot find config for profile '${profileKey}'. Configure the CLI with the following command:\n\n $ growthbook auth login`,
+      )
     }
   }
 
-  return config;
+  return config
 }


### PR DESCRIPTION
The error currently being displayed when a user is trying to use a custom profile and it doesn't exist references the `DEFAULT_GROWTHBOOK_PROFILE` instead of the `profileKey` 